### PR TITLE
FIX: Use correct link in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # go-connect-memcached
-An implementation of encrypt and decrypt algorithm of [connect-memcached](git@github.com:barunthapa/go-connect-memcached.git) in Golang.
+An implementation of encrypt and decrypt algorithm of [connect-memcached](https://github.com/balor/connect-memcached) in Golang.


### PR DESCRIPTION
Fix the link to the [connect-memcached](https://github.com/balor/connect-memcached) JS library in the readme document.